### PR TITLE
Mongo authenticate mechanism wasn't connecting with SSL/TLS if it was…

### DIFF
--- a/mongoaudit/testers/testers.py
+++ b/mongoaudit/testers/testers.py
@@ -234,13 +234,22 @@ def try_dedicated_user(test):
 
 def try_scram(test):
     try:
-        conn = test.tester.get_connection()
+        clean_up_connection(test)
         cred = test.tester.cred
-        return TestResult(success=conn[cred["database"]].authenticate(cred["username"],
-                                                                      cred["password"],
-                                                                      mechanism='SCRAM-SHA-1'))
+        return TestResult(success=test.tester.conn[cred["database"]]
+                          .authenticate(cred["username"],
+                                        cred["password"],
+                                        source=cred["database"],
+                                        mechanism='SCRAM-SHA-1'))
     except (pymongo.errors.OperationFailure, ValueError, TypeError):
         return TestResult(success=False)
+
+
+def clean_up_connection(test):
+    test.tester.conn.close()
+    del test.tester.conn
+    test.tester.conn = test.tester.get_connection()
+    test.tester.get_info()
 
 
 @decorators.requires_userinfo


### PR DESCRIPTION
… enabled nor using a specific database. Closes #26

Another quick fix. clean_up_connection() is a kind of hack due the weird way of getting a connection. There is a lot of space for improvement here.

Signed-off-by: Sebastian Rajo <elecay@gmail.com>